### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]


### PR DESCRIPTION
Potential fix for [https://github.com/robertmuil/pythinfer/security/code-scanning/1](https://github.com/robertmuil/pythinfer/security/code-scanning/1)

In general, fix this by explicitly defining a `permissions:` block that restricts the GITHUB_TOKEN to the minimum required scopes, either at the workflow root or per job. For this workflow, the steps only need to read repository contents (for checkout and test execution); uploads to Codecov are done via `CODECOV_TOKEN`, not the GITHUB_TOKEN. Therefore the least-privilege useful setting is `permissions: contents: read` for the `test` job.

Concretely, in `.github/workflows/test.yml`, under `jobs:`, inside the `test:` job definition and at the same indentation level as `runs-on:`, add a `permissions:` block with `contents: read`. This keeps the change localized to the highlighted job, avoids altering behavior, and satisfies CodeQL by constraining the default GITHUB_TOKEN permissions. No additional imports or methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
