### PR TITLE
allow extra fields in project spec

### DIFF
--- a/src/pythinfer/project.py
+++ b/src/pythinfer/project.py
@@ -80,7 +80,7 @@ class ProjectSpec(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra="forbid",  # This rejects unexpected keys
+        extra="ignore",  # Allow superset config files from downstream programs
         arbitrary_types_allowed=True,  # Allows Path objects
     )
 

--- a/tests/unit/inout/test_project_validation.py
+++ b/tests/unit/inout/test_project_validation.py
@@ -72,20 +72,20 @@ class TestProjectValidConfiguration:
 class TestProjectInvalidConfiguration:
     """Test invalid Project configurations that should raise ValidationError."""
 
-    def test_rejects_unexpected_field(self, tmp_path: Path) -> None:
-        """Test that Project rejects config with unexpected fields."""
+    def test_ignores_unexpected_field(self, tmp_path: Path) -> None:
+        """Test that Project silently ignores unrecognised fields."""
         config_path = tmp_path / "test.yaml"
         config = {
             "name": "test-project",
             "path_self": config_path,
             "focus": ["file1.ttl"],
-            "unexpected_field": "this should cause an error",
+            "unexpected_field": "this should be ignored",
         }
 
-        with pytest.raises(ValidationError) as exc_info:
-            ProjectSpec(**config)
+        project = ProjectSpec(**config)
 
-        assert "unexpected_field" in str(exc_info.value)
+        assert project.name == "test-project"
+        assert not hasattr(project, "unexpected_field")
 
     def test_rejects_missing_required_name(self, tmp_path: Path) -> None:
         """Test that Project requires 'name' field."""


### PR DESCRIPTION
allows for downstream programs to use their own project files if they're a superset of what pythinfer requires

Fixes https://github.com/robertmuil/pythinfer/issues/68